### PR TITLE
Revert "expose a static dep to use as subproject"

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -192,24 +192,6 @@ wlroots = declare_dependency(
 	include_directories: wlr_inc,
 )
 
-
-lib_wlr_static = static_library(
-	meson.project_name(),
-	version: '.'.join(so_version),
-	link_whole: wlr_parts,
-	dependencies: wlr_deps,
-	include_directories: wlr_inc,
-	install: true,
-	link_args : symbols_flag,
-	link_depends: symbols_file,
-)
-
-wlroots_static_dep = declare_dependency(
-	link_with: lib_wlr_static,
-	dependencies: wlr_deps,
-	include_directories: wlr_inc,
-)
-
 summary = [
 	'',
 	'----------------',


### PR DESCRIPTION
This reverts commit cccd0a099d6dacd2c86e29a977eabf716ada4699.

This is necessary to use the per-subproject Meson option `default_library=static`, otherwise Meson complains about two targets having the same name.

See https://github.com/Plagman/gamescope/pull/45