### PR TITLE
Revert "build: include headers in protocol directory explicitly"

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -87,7 +87,7 @@ conf_data.set10('WLR_HAS_XWAYLAND', false)
 conf_data.set10('WLR_HAS_XCB_ERRORS', false)
 conf_data.set10('WLR_HAS_XCB_ICCCM', false)
 
-wlr_inc = include_directories('.', 'include', 'protocol')
+wlr_inc = include_directories('.', 'include')
 
 # Clang complains about some zeroed initializer lists (= {0}), even though they
 # are valid


### PR DESCRIPTION
This reverts commit 49e33be5bf15fab9530013a7b862eaa0ecfb5161.

These headers aren't used in gamescope, builds fine without it. If
gamescope needs these headers, it should use wayland-protocols to
generate them instead of relying on wlroots. wlroots doesn't expose
wayland-protocols headers.